### PR TITLE
Added configuration file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/ 
+
+# Configuration file
+**/user_config.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm==4.58.0
 verboselogs==1.7
 ffmpeg_python==0.2.0
 ffmpeg==1.4
+pyyaml==5.4.1

--- a/saveddit/configuration.py
+++ b/saveddit/configuration.py
@@ -1,0 +1,59 @@
+import os
+from typing import Union
+import yaml
+import pathlib
+import colorama
+import sys
+
+
+class ConfigurationLoader:
+    PURPLE = colorama.Fore.MAGENTA
+    WHITE = colorama.Style.RESET_ALL
+    RED = colorama.Fore.RED
+
+    @staticmethod
+    def load(path):
+        """
+        Loads Saveddit configuration from a configuration file.
+        If ifle is not found, create one and exit.
+
+        Arguments:
+            path: path to user_config.yaml file
+
+        Returns:
+            A Python dictionary with Saveddit configuration info
+        """
+
+        def _create_config(_path):
+            _STD_CONFIG = {
+                "reddit_client_id": "",
+                "reddit_client_secret": "",
+                "imgur_client_id": "",
+            }
+            with open(_path, "x") as _f:
+                yaml.dump(_STD_CONFIG, _f)
+            sys.exit(0)
+
+        # Explicitly converting path to POSIX-like path (to avoid '\\' hell)
+        print(
+            "{notice}Retrieving configuration from {path} file{white}".format(
+                path=os.path.basename(path),
+                notice=ConfigurationLoader.PURPLE,
+                white=ConfigurationLoader.WHITE,
+            )
+        )
+        path = pathlib.Path(path).absolute().as_posix()
+
+        # Check if file exists. If not, create one and fill it with std config template
+        if not os.path.exists(path):
+            print(
+                "{red}No configuration file found.\nCreating one. Please edit {path} with valid credentials.\nExiting{white}".format(
+                    red=ConfigurationLoader.RED,
+                    path=path,
+                    white=ConfigurationLoader.WHITE,
+                )
+            )
+            _create_config(path)
+
+        with open(path, "r") as _f:
+            return yaml.safe_load(_f.read())

--- a/saveddit/subreddit_downloader.py
+++ b/saveddit/subreddit_downloader.py
@@ -14,12 +14,16 @@ import requests
 from tqdm import tqdm
 import urllib.request
 import youtube_dl
-
+from saveddit.configuration import ConfigurationLoader
 
 class SubredditDownloader:
-    REDDIT_CLIENT_ID = "aCjKJeNwZw_Efg"
-    REDDIT_CLIENT_SECRET = "1Hul2-xgH_11r6limxcdtnPFQ4V5AQ"
-    IMGUR_CLIENT_ID = "33982ca3205a4a2"
+    config = ConfigurationLoader.load(os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../", "user_config.yaml")
+        ))
+
+    REDDIT_CLIENT_ID = config['reddit_client_id']
+    REDDIT_CLIENT_SECRET = config['reddit_client_secret']
+    IMGUR_CLIENT_ID = config['imgur_client_id']
     DEFAULT_CATEGORIES = ["hot", "new", "rising",
                           "controversial", "top", "gilded"]
     DEFAULT_POST_LIMIT = None


### PR DESCRIPTION
All website IDs and secrets were moved to an external file called 'user_config.yaml'. Also a new saveddit.configuration module was created for parsing thic configuration file.

This module is searching for a file and, if does not find one, creates an empty configuration file, prompts user to place his valid credentials into this file and exits the script.

New dependency was added: pyyaml==5.4.1

'user_config.yaml' file was added to .gitignore to prevent sensetive data leak.